### PR TITLE
Update patch notice for Entry-11::Recaf

### DIFF
--- a/decompiler-tool-bugs/entry-011/entry.md
+++ b/decompiler-tool-bugs/entry-011/entry.md
@@ -148,7 +148,7 @@ Recaf will either represent the class incorrectly or crash due to its reliance o
 
 #### Patch Date
 
-N/A
+2020-07-24
 
 ## dirtyJOE
 

--- a/quicklinks.md
+++ b/quicklinks.md
@@ -100,4 +100,4 @@ Provides links specific to tools.
 
 ## [Recaf](https://github.com/Col-E/Recaf)
 
-[entry-011](decompiler-tool-bugs/entry-011/entry.md)
+[entry-011](decompiler-tool-bugs/entry-011/entry.md)  (PATCHED)


### PR DESCRIPTION
Recaf now supports reading oak class files as of July 24th 2020. The entry/quick-links have been updated to reflect this.